### PR TITLE
Build on macOS to enable automatic Code Signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
             - 'RELEASE.md'
             - 'CONTRIBUTING.md'
     pull_request:
+    release:
 
 jobs:
     build:
@@ -34,11 +35,7 @@ jobs:
               run: dotnet run --project src/Tests
 
             - name: Publish 🚀
-              if: github.event_name == 'push'
+              if: github.event_name == 'release'
               run: |
-                  if ( "${{github.ref}}" -match "^refs/tags/[0-9]+\.[0-9]+\.[0-9]+" ) {
-                      dotnet tool install --global dotnet-releaser --version "0.1.*"
-                      dotnet-releaser publish --github-token ${{secrets.TOKEN_GITHUB}} src/dotnet-releaser.toml
-                  } else {
-                      echo "publish is only enabled by tagging with a release tag"
-                  }
+                  dotnet tool install --global dotnet-releaser --version "0.1.*"
+                  dotnet-releaser publish --github-token ${{secrets.TOKEN_GITHUB}} src/dotnet-releaser.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
     build:
-        runs-on: windows-latest
+        runs-on: macos-latest
 
         steps:
             - name: Checkout 🛎️


### PR DESCRIPTION
Telling from https://github.com/dotnet/sdk/issues/21123 App Signing seems a requirement for apps to run on Apple Silicon and macOS > 11. 
The dotnet SDK signs the app automatically when it runs on macOS so I changed the build to run on Mac instead.

Alternatively one would need to do this manually like in this [doc](https://docs.microsoft.com/en-us/dotnet/standard/assembly/sign-strong-name). 
TL;DR: generate a key with [sn.exe](https://docs.microsoft.com/en-us/dotnet/framework/tools/sn-exe-strong-name-tool) commit the file and then add it to the fsproj like [so](https://github.com/scriban/scriban/blob/master/src/Scriban.Signed/Scriban.Signed.csproj). 
For now this seems like extra trouble I don't want to go through.

This could potentially solve #3 