### PR TITLE
Update CI to only trigger builds for published releases 🧰

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
             - 'CONTRIBUTING.md'
     pull_request:
     release:
+        types: 
+            - published
+            - prereleased
 
 jobs:
     build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,8 @@ on:
             - 'CONTRIBUTING.md'
     pull_request:
     release:
-        types: 
+        types:
             - published
-            - prereleased
 
 jobs:
     build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
               with:
                   dotnet-version: '6.0.x'
 
-            - name: Install dependencies 🔌
+            - name: Install dependencies 📦
               run: dotnet restore src
 
             - name: Build project 🏗
@@ -39,5 +39,5 @@ jobs:
             - name: Publish 🚀
               if: github.event_name == 'release'
               run: |
-                  dotnet tool install --global dotnet-releaser --version "0.1.*"
+                  dotnet tool install --global dotnet-releaser --version "0.3.*"
                   dotnet-releaser publish --github-token ${{secrets.TOKEN_GITHUB}} src/dotnet-releaser.toml


### PR DESCRIPTION
Otherwise this resulted in 3-4 different builds because of the different events