### PR TITLE
Improve -s to also skip the download when the file already exists ✨

### DIFF
--- a/src/SwitchTubeDl/Cli/ArgParse.fs
+++ b/src/SwitchTubeDl/Cli/ArgParse.fs
@@ -2,6 +2,7 @@ namespace TubeDl.Cli
 
 open Argu
 open FsToolkit.ErrorHandling
+open Microsoft.FSharpLu
 
 open TubeDl
 open TubeDl.Cli
@@ -83,9 +84,12 @@ module CliArgParse =
         | true ->
             let path = results.GetResult CliArgs.Path
 
-            match Path.isFullyQualified path with
-            | true -> Ok path
-            | false -> Error InvalidPath
+            let fullyQualified = Path.isFullyQualified path
+            let valid = File.validateFilePath path
+
+            match fullyQualified, valid with
+            | true, Some _ -> Ok path
+            | _ -> Error InvalidPath
         | false -> Env.workingDir |> Ok
 
     let tryGetChannelFilter (results : ParseRes) =

--- a/src/SwitchTubeDl/Cli/ArgParse.fs
+++ b/src/SwitchTubeDl/Cli/ArgParse.fs
@@ -33,7 +33,7 @@ type CliCfg =
         ChannelFilter : ChannelFilter option
     }
 
-type ValidatedCfg =
+type CompleteCfg =
     {
         DownloadType : DownloadType
         Token : Api.Token
@@ -42,7 +42,7 @@ type ValidatedCfg =
         ChannelFilter : ChannelFilter option
     }
 
-module ValidatedCfg =
+module CompleteCfg =
     let unsafeFromCliCfg (cliCfg : CliCfg) =
         {
             DownloadType = cliCfg.DownloadType

--- a/src/SwitchTubeDl/Cli/Cli.fs
+++ b/src/SwitchTubeDl/Cli/Cli.fs
@@ -18,8 +18,7 @@ type CliArgs =
             | Video _ -> "Download type. Downloads a specific video. Prioritized if multiple download types are given"
             | Channel _ ->
                 "Download type. Download videos from this channel. Starts in interactive mode if no filter option is given"
-            | Token _ ->
-                "Token to access the SwitchTube API. Generate a token at https://tube.switch.ch/access_tokens"
+            | Token _ -> "Token to access the SwitchTube API. Generate a token at https://tube.switch.ch/access_tokens"
             | Path _ -> "Paths to download videos to (defaults to current dir). The path must already exist."
             | Skip ->
                 "Existing file handling option. Skip saving of already existing files. Prioritized if multiple existing file options are given"

--- a/src/SwitchTubeDl/Cli/CliError.fs
+++ b/src/SwitchTubeDl/Cli/CliError.fs
@@ -53,6 +53,11 @@ module CliError =
         | DownloadError dlErr ->
 
         match dlErr with
-        | TubeInfoError (TubeInfoError.ApiError _) -> 2
-        | TubeInfoError (TubeInfoError.DecodeError _) -> 3
-        | SaveFileError _ -> 4
+        | TubeInfoError (TubeInfoError.ApiError apiErr) ->
+            match apiErr with
+            | Api.UnauthorizedAccess -> 2
+            | Api.ResourceNotFound -> 3
+            | Api.TooManyRequests -> 5
+            | Api.ApiError -> 6
+        | TubeInfoError (TubeInfoError.DecodeError _) -> 7
+        | SaveFileError _ -> 8

--- a/src/SwitchTubeDl/Cli/CliError.fs
+++ b/src/SwitchTubeDl/Cli/CliError.fs
@@ -8,7 +8,7 @@ type DownloadError =
     | SaveFileError of SaveFileError
 
 module DownloadError =
-    let errorMsg (cfg : ValidatedCfg) (error : DownloadError) =
+    let errorMsg (cfg : CompleteCfg) (error : DownloadError) =
         let apiErrorMsg =
             function
             | Api.UnauthorizedAccess -> "A valid token needs to be provided."

--- a/src/SwitchTubeDl/Download/Download.fs
+++ b/src/SwitchTubeDl/Download/Download.fs
@@ -31,12 +31,12 @@ let runDownload res =
     | Error InvalidPath ->
         eprintfn "The given path should be absolute"
         Error ArgumentsNotSpecified
-    | Ok cfg ->
+    | Ok cliCfg ->
 
-    let cfg = withToken cfg |> ValidatedCfg.unsafeFromCliCfg
+    let cfg = withToken cliCfg |> CompleteCfg.unsafeFromCliCfg
 
     let printError e =
-        let errorMsg = DownloadError.errorMsg cfg e // This fun should escape content correctly as it also contains markup
+        let errorMsg = DownloadError.errorMsg cfg e // This fun should escape its content correctly as it also contains markup
         Markup.eprintn $":collision: [bold red]Failure![/] %s{errorMsg}"
 
     match cfg.DownloadType with

--- a/src/SwitchTubeDl/Download/DownloadChannel.fs
+++ b/src/SwitchTubeDl/Download/DownloadChannel.fs
@@ -121,7 +121,7 @@ let private runDownloadFromDetails cfg metadata videoDetails =
                         $"[yellow bold]Saved video[/] \"[italic]%s{esc video}[/]\" as \"[italic]%s{esc fileName}[/]\""
                         |> Markup.log
                     | FileWriteResult.Skipped ->
-                        $"[yellow bold]Skipped[/] saving of video \"[italic]%s{esc video}[/]\" as it already exists and the skip option was provided"
+                        $"[yellow bold]Skipped[/] saving of video \"[italic]%s{esc video}[/]\" as it already exists"
                         |> Markup.log
 
                 return! downloadVideos cfg showFinishedStep videoDetails

--- a/src/SwitchTubeDl/HandleFiles.fs
+++ b/src/SwitchTubeDl/HandleFiles.fs
@@ -86,7 +86,7 @@ module HandleFiles =
         asyncResult {
             use! file =
                 try
-                    File.Create path |> Ok
+                    File.create path |> Ok
                 with
                 | :? System.UnauthorizedAccessException -> Error SaveFileError.AccessDenied
                 | :? DirectoryNotFoundException -> Error SaveFileError.DirNotFound
@@ -111,7 +111,7 @@ module HandleFiles =
         let (FullPath path) = fullPath
 
         async {
-            match File.Exists path, overwrite with
+            match File.exists path, overwrite with
             | true, ExistingFilesHandling.KeepAsIs -> return Error (SaveFileError.FileExists fullPath)
             | true, ExistingFilesHandling.Skip -> return Ok FileWriteResult.Skipped
             | true, ExistingFilesHandling.Overwrite
@@ -135,9 +135,10 @@ module HandleFiles =
 
     let fullPath basePath file = Path.combine basePath file |> FullPath
 
-    let saveVideo overwrite basePath videoDetails videoPath stream =
-        let path =
-            fileName videoDetails videoPath
-            |> fullPath basePath
+    let fullPathForVideo basePath videoDetails videoPath =
+        fileName videoDetails videoPath
+        |> fullPath basePath
 
+    let saveVideo overwrite basePath videoDetails videoPath stream =
+        let path = fullPathForVideo basePath videoDetails videoPath
         saveFileFromStream overwrite path stream

--- a/src/SwitchTubeDl/Interop/File.fs
+++ b/src/SwitchTubeDl/Interop/File.fs
@@ -1,0 +1,7 @@
+module TubeDl.File
+
+open System.IO
+
+let create = File.Create
+
+let exists = File.Exists

--- a/src/SwitchTubeDl/SwitchTubeDl.fsproj
+++ b/src/SwitchTubeDl/SwitchTubeDl.fsproj
@@ -25,6 +25,7 @@
         <Compile Include="Interop\Env.fs" />
         <Compile Include="Interop\DateTime.fs" />
         <Compile Include="Interop\Regex.fs" />
+        <Compile Include="Interop\File.fs" />
         <Compile Include="List.fs" />
         <Compile Include="Int.fs" />
         <Compile Include="Api\Entities.fs" />

--- a/src/Tests/HandleFiles.fs
+++ b/src/Tests/HandleFiles.fs
@@ -35,7 +35,6 @@ let private fileNameTests =
                 Expect.equal fileName "A_really_cool_video_about_auo_TheId.mp4" "Didn't handle suboptimal chars"
         ]
 
-
 let private fullPathTests =
     testList
         "fullPath"


### PR DESCRIPTION
It is not necessary that the video data is downloaded when it already exists. Now this is detected and the download is skipped.

Also contains small refactorings.